### PR TITLE
Fix for error: called object 'socket' is not a function or function p…

### DIFF
--- a/components/oap-http/esp_request.c
+++ b/components/oap-http/esp_request.c
@@ -110,7 +110,7 @@ static char *http_auth_basic_encode(const char *username, const char *password)
 
 static int nossl_connect(request_t *req)
 {
-    int socket;
+    int socket_esp;
     struct sockaddr_in remote_ip;
     struct timeval tv;
     req_list_t *host, *port, *timeout;
@@ -125,8 +125,8 @@ static int nossl_connect(request_t *req)
         }
     }
 
-    socket = socket(PF_INET, SOCK_STREAM, 0);
-    REQ_CHECK(socket < 0, "socket failed", return -1);
+    socket_esp = socket(PF_INET, SOCK_STREAM, 0);
+    REQ_CHECK(socket_esp < 0, "socket failed", return -1);
 
     port = req_list_get_key(req->opt, "port");
     if(port == NULL)
@@ -141,16 +141,16 @@ static int nossl_connect(request_t *req)
         tv.tv_sec = atoi(timeout->value);
     }
     tv.tv_usec = 0;
-    setsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    setsockopt(socket_esp, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
 
     ESP_LOGD(TAG, "[sock=%d],connecting to server IP:%s,Port:%s...",
-             socket, ipaddr_ntoa((const ip_addr_t*)&remote_ip.sin_addr.s_addr), (char*)port->value);
-    if(connect(socket, (struct sockaddr *)(&remote_ip), sizeof(struct sockaddr)) != 0) {
-        close(socket);
+             socket_esp, ipaddr_ntoa((const ip_addr_t*)&remote_ip.sin_addr.s_addr), (char*)port->value);
+    if(connect(socket_esp, (struct sockaddr *)(&remote_ip), sizeof(struct sockaddr)) != 0) {
+        close(socket_esp);
         return -1;
     }
-    req->socket = socket;
-    return socket;
+    req->socket = socket_esp;
+    return socket_esp;
 }
 
 void req_free_x509_crt(mbedtls_x509_crt* crt) {


### PR DESCRIPTION
Fix for Issue reported: https://github.com/openairproject/sensor-esp32/issues/50

Changed the name of socket variable.
